### PR TITLE
fix idempotency windows

### DIFF
--- a/manifests/install_windows.pp
+++ b/manifests/install_windows.pp
@@ -90,7 +90,7 @@ class azurelaagent::install_windows (
     exec { 'LA_Agent_installation':
       command  => $install_command,
       #unless   => "if (Test-Path -Path \"${path_to_test_installation}\") {exit 0} else {exit 1}",
-      unless   => "if  (Get-WMIObject  -Query 'SELECT * FROM Win32_Product Where Name Like "Microsoft Monitoring Agent"'') { $true } else { $false }",      
+      unless   => "if  (Get-WMIObject  -Query 'SELECT * FROM Win32_Product Where Name Like "Microsoft Monitoring Agent"'') {exit 0} else {exit 1}",      
       provider => powershell,
       require  => Exec['MMASetup.exe_extraction'],
     }

--- a/manifests/install_windows.pp
+++ b/manifests/install_windows.pp
@@ -89,7 +89,8 @@ class azurelaagent::install_windows (
     # Agent installation
     exec { 'LA_Agent_installation':
       command  => $install_command,
-      unless   => "if (Test-Path -Path \"${path_to_test_installation}\") {exit 0} else {exit 1}",
+      #unless   => "if (Test-Path -Path \"${path_to_test_installation}\") {exit 0} else {exit 1}",
+      unless   => "if  (Get-WMIObject  -Query 'SELECT * FROM Win32_Product Where Name Like "Microsoft Monitoring Agent"'') { $true } else { $false }",      
       provider => powershell,
       require  => Exec['MMASetup.exe_extraction'],
     }


### PR DESCRIPTION
Install on windows could fail when install folder was not removed by uninstall. Fixed by checking with wmi for 'Microsoft Monitor Agent'