### PR TITLE
Allow the agent to be upgraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To remove the proxy settings after installation
     ensure => 'absent',
   }
 ```
-### Upgrading the agent
+### Upgrading the Linux agent
 You can install a specific version of the agent by setting hiera variables to control the version downloaded `x64_download_path` and what filename to save the download to `downloaded_script`.
 ```yaml
 azurelaagent::install_linux::x64_download_path: https://github.com/microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_v1.14.12-0/omsagent-1.14.12-0.universal.x64.sh
@@ -99,6 +99,9 @@ azurelaagent::install_linux::x64_download_path: https://github.com/microsoft/OMS
 azurelaagent::install_linux::downloaded_script: omsagent-1.14.16-0.universal.x64.sh
 ```
 This will cause the new version to be downloaded an an in-place upgrade will occur preserving the original `SourceComputerId` in Azure Log Analytics.
+### Upgrading the Windows agent
+Due to the way Microsoft packages and distributes the agent it is not possible to use above technique to upgrade the agent. The Windows agent ULR is always [https://go.microsoft.com/fwlink/?LinkId=828603](https://go.microsoft.com/fwlink/?LinkId=828603) and downloads the latest version. But you don't know the version until it is downloaded.
+
 
 ### Uninstalling the agent
 To uninstall the agent

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Example
 
 To install the agent
 
-```
+```puppet
   class { 'azurelaagent':
     azure_id     => 'your_workspace_id',
     azure_shared => 'your_shared_key',
@@ -45,7 +45,7 @@ To install the agent
 
 To modify workspace id and key after installation
 
-```
+```puppet
   class { 'azurelaagent::config':
     azure_id     => 'your_workspace_id',
     azure_shared => 'your_shared_key',
@@ -56,7 +56,7 @@ To modify the proxy settings after installation
 
 Unauthenticated proxy
 
-```
+```puppet
   class {'azurelaagent::config_proxy':
     proxy_server   => 'http://your.proxy:port',
   }
@@ -64,7 +64,7 @@ Unauthenticated proxy
 
 Authenticated proxy
 
-```
+```puppet
   class {'azurelaagent::config_proxy':
     proxy_server   => 'http://your.proxy:port',
     proxy_user     => 'username',
@@ -74,15 +74,36 @@ Authenticated proxy
 
 To remove the proxy settings after installation
 
-```
+```puppet
   class {'azurelaagent::config_proxy':
     ensure => 'absent',
   }
 ```
+### Upgrading the agent
+You can install a specific version of the agent by setting hiera variables to control the version downloaded `x64_download_path` and what filename to save the download to `downloaded_script`.
+```yaml
+azurelaagent::install_linux::x64_download_path: https://github.com/microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_v1.14.12-0/omsagent-1.14.12-0.universal.x64.sh
+azurelaagent::install_linux::downloaded_script: omsagent-1.14.12-0.universal.x64.sh
+```
+To upgrade the agent set the ensure parameter to `latest`
+```puppet
+  class { 'azurelaagent':
+    azure_id     => 'your_workspace_id',
+    azure_shared => 'your_shared_key',
+    ensure       => latest,
+  }
+```
+And change the hiera variables to point a new version to download and a new filename to save the download.
+```yaml
+azurelaagent::install_linux::x64_download_path: https://github.com/microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_v1.14.16-0/omsagent-1.14.16-0.universal.x64.sh
+azurelaagent::install_linux::downloaded_script: omsagent-1.14.16-0.universal.x64.sh
+```
+This will cause the new version to be downloaded an an in-place upgrade will occur preserving the original `SourceComputerId` in Azure Log Analytics.
 
+### Uninstalling the agent
 To uninstall the agent
 
-```
+```puppet
   class { 'azurelaagent':
     ensure => 'absent',
   }
@@ -92,10 +113,10 @@ To uninstall the agent
 
 If you need to change specific data in Linux or Windows installation use yaml files like
 
-```
+```yaml
 azurelaagent::install_linux::x64_download_path: 'https://github.com/Microsoft/OMS-Agent-for-Linux/releases/download/OMSAgent_v1.8.1.256/omsagent-1.8.1-256.universal.x64.sh'
 ```
-```
+```yaml
 azurelaagent::install_windows::x64_download_path: 'https://go.microsoft.com/fwlink/?LinkId=828603'
 ```
 

--- a/lib/facter/omsagent.rb
+++ b/lib/facter/omsagent.rb
@@ -1,7 +1,5 @@
 Facter.add(:omsagent) do
-    confine :kernel do |value|
-        value == "Linux"
-    end
+    confine :kernel => :linux
     setcode do
         omsagent = {}
         if File.exists?("/opt/microsoft/omsagent/bin/omsadmin.sh")

--- a/lib/facter/omsagent.rb
+++ b/lib/facter/omsagent.rb
@@ -1,0 +1,14 @@
+Facter.add(:omsagent) do
+    confine :kernel do |value|
+        value == "Linux"
+    end
+    setcode do
+        omsagent_hash = {}
+        if File.exists?("/opt/microsoft/omsagent/bin/omsadmin.sh") do
+            omsagent_hash['installed'] = true
+        else
+            omsagent_hash['installed'] = false
+        end
+        omsagent_hash
+    end
+end

--- a/lib/facter/omsagent.rb
+++ b/lib/facter/omsagent.rb
@@ -3,12 +3,12 @@ Facter.add(:omsagent) do
         value == "Linux"
     end
     setcode do
-        omsagent_hash = {}
-        if File.exists?("/opt/microsoft/omsagent/bin/omsadmin.sh") do
-            omsagent_hash['installed'] = true
+        omsagent = {}
+        if File.exists?("/opt/microsoft/omsagent/bin/omsadmin.sh")
+            omsagent['installed'] = true
         else
-            omsagent_hash['installed'] = false
+            omsagent['installed'] = false
         end
-        omsagent_hash
+        omsagent
     end
 end

--- a/manifests/install_linux.pp
+++ b/manifests/install_linux.pp
@@ -68,7 +68,7 @@ class azurelaagent::install_linux (
     mode => '0744',
   }
 
-  if (($ensure == 'present' or $ensure == 'latest') and $facts['omsagent']['installed'] == false) {
+  if (($ensure == 'present' or $ensure == 'latest') and $::facts['omsagent']['installed'] == false) {
     # Install Agent
 
     # package {$packages_to_install:
@@ -89,7 +89,7 @@ class azurelaagent::install_linux (
       require => Exec['OMSAgent install script download'],
     }
 
-  } elsif($ensure == 'latest' and $facts['omsagent']['installed]'] == true) {
+  } elsif($ensure == 'latest' and $::facts['omsagent']['installed'] == true) {
     if ($use_proxy and $proxy != '' and $proxy != undef) {
       $upgrade_command = "${path_to_download}/${downloaded_script} --upgrade -p ${proxy} -w ${azure_id} -s ${azure_shared}"
     } else {

--- a/manifests/install_linux.pp
+++ b/manifests/install_linux.pp
@@ -68,7 +68,7 @@ class azurelaagent::install_linux (
     mode => '0744',
   }
 
-  if ($ensure == 'present') {
+  if (($ensure == 'present' or $ensure == 'latest') and $facts['omsagent']['installed]'] == false) {
     # Install Agent
 
     # package {$packages_to_install:
@@ -89,7 +89,7 @@ class azurelaagent::install_linux (
       require => Exec['OMSAgent install script download'],
     }
 
-  } elsif($ensure == 'latest') {
+  } elsif($ensure == 'latest' and $facts['omsagent']['installed]'] == true) {
     if ($use_proxy and $proxy != '' and $proxy != undef) {
       $upgrade_command = "${path_to_download}/${downloaded_script} --upgrade -p ${proxy} -w ${azure_id} -s ${azure_shared}"
     } else {

--- a/manifests/install_linux.pp
+++ b/manifests/install_linux.pp
@@ -68,7 +68,7 @@ class azurelaagent::install_linux (
     mode => '0744',
   }
 
-  if (($ensure == 'present' or $ensure == 'latest') and $facts['omsagent']['installed]'] == false) {
+  if (($ensure == 'present' or $ensure == 'latest') and $facts['omsagent']['installed'] == false) {
     # Install Agent
 
     # package {$packages_to_install:

--- a/manifests/install_linux.pp
+++ b/manifests/install_linux.pp
@@ -76,9 +76,9 @@ class azurelaagent::install_linux (
     # }
 
     if ($use_proxy and $proxy != '' and $proxy != undef) {
-      $install_command = "${path_to_download}/${downloaded_script} --upgrade -p ${proxy} -w ${azure_id} -s ${azure_shared}"
+      $install_command = "${path_to_download}/${downloaded_script} --install -p ${proxy} -w ${azure_id} -s ${azure_shared}"
     } else {
-      $install_command = "${path_to_download}/${downloaded_script} --upgrade -w ${azure_id} -s ${azure_shared}"
+      $install_command = "${path_to_download}/${downloaded_script} --install -w ${azure_id} -s ${azure_shared}"
     }
 
     # Agent installation
@@ -89,6 +89,20 @@ class azurelaagent::install_linux (
       require => Exec['OMSAgent install script download'],
     }
 
+  } elsif($ensure == 'latest') {
+    if ($use_proxy and $proxy != '' and $proxy != undef) {
+      $upgrade_command = "${path_to_download}/${downloaded_script} --upgrade -p ${proxy} -w ${azure_id} -s ${azure_shared}"
+    } else {
+      $upgrade_command = "${path_to_download}/${downloaded_script} --upgrade -w ${azure_id} -s ${azure_shared}"
+    }
+
+    # Agent installation
+    exec { 'OMSAgent installation':
+      path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin',
+      command => $upgrade_command,
+      onlyif  => 'test -f /opt/microsoft/omsagent/bin/omsadmin.sh',
+      require => Exec['OMSAgent install script download'],
+    }
   } elsif ($ensure == 'absent') {
     # Uninstall Agent
     exec { 'OMSAgent uninstallation':


### PR DESCRIPTION
Minor change to the code to introduce a new `ensure` value entitled `latest` which when combined with the use of the `x64_download_path` and `downloaded_script` parameters stored in Hiera allows the version to be upgraded in place.